### PR TITLE
Add ReadFrom and WriteTo methods

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -3,6 +3,8 @@ package mafsa
 import (
 	"encoding/binary"
 	"errors"
+	"io"
+	"io/ioutil"
 )
 
 // Decoder is a type which can decode a byte slice into a MinTree.
@@ -18,6 +20,18 @@ type Decoder struct {
 // Decode transforms the binary serialization of a MA-FSA into a
 // new MinTree (a read-only MA-FSA).
 func (d *Decoder) Decode(data []byte) (*MinTree, error) {
+	tree := newMinTree()
+	return tree, d.decodeMinTree(tree, data)
+}
+
+// ReadFrom reads the binary serialization of a MA-FSA into a
+// new MinTree (a read-only MA-FSA) from a io.Reader.
+func (d *Decoder) ReadFrom(r io.Reader) (*MinTree, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
 	tree := newMinTree()
 	return tree, d.decodeMinTree(tree, data)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -1,7 +1,9 @@
 package mafsa
 
 import (
+	"bytes"
 	"encoding/binary"
+	"io"
 	"sort"
 )
 
@@ -43,6 +45,21 @@ func (e *Encoder) Encode(t *BuildTree) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+// WriteTo encodes and saves the BuildTree to a io.Writer.
+func (e *Encoder) WriteTo(wr io.Writer, t *BuildTree) error {
+	bs, err := e.Encode(t)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(wr, bytes.NewReader(bs))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // encodeEdges encodes the edges going out of node into bytes which are appended

--- a/mafsa.go
+++ b/mafsa.go
@@ -1,6 +1,6 @@
 package mafsa
 
-import "io/ioutil"
+import "os"
 
 // New constructs a new, empty MA-FSA that can be filled with data.
 func New() *BuildTree {
@@ -14,12 +14,11 @@ func New() *BuildTree {
 // Load loads an existing MA-FSA from a file specified by filename.
 // It returns a read-only MA-FSA, or an error if loading failed.
 func Load(filename string) (*MinTree, error) {
-	data, err := ioutil.ReadFile(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-
-	mtree, err := new(Decoder).Decode(data)
+	mtree, err := new(Decoder).ReadFrom(f)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These operate on the io.Writer/io.Reader interfaces which should make them
more widely applicable. We also change the Load function to use ReadFrom.